### PR TITLE
feat: add multi-select bulk configure for discovered apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.6] - 2026-02-05
+
+### Added
+- **Multi-select bulk configure for discovered apps** — select multiple discovered apps via checkboxes and configure category and groups in a single operation (#6)
+
 ## [1.0.5] - 2026-02-05
 
 ### Fixed

--- a/internal/handlers/discovered.go
+++ b/internal/handlers/discovered.go
@@ -31,6 +31,90 @@ func DiscoveredAppsHandler(app *server.App) http.HandlerFunc {
 	}
 }
 
+// BulkDiscoveredAppsRequest is the request body for bulk operations.
+type BulkDiscoveredAppsRequest struct {
+	URLs     []string `json:"urls"`
+	Action   string   `json:"action"` // "show" - configure apps with category and groups
+	Category string   `json:"category,omitempty"`
+	Groups   []string `json:"groups,omitempty"`
+}
+
+// BulkDiscoveredAppsHandler handles bulk operations on discovered apps.
+func BulkDiscoveredAppsHandler(app *server.App) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		var req BulkDiscoveredAppsRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "Invalid JSON: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		if len(req.URLs) == 0 {
+			http.Error(w, "No URLs provided", http.StatusBadRequest)
+			return
+		}
+
+		// Limit batch size to prevent abuse
+		const maxBulkURLs = 100
+		if len(req.URLs) > maxBulkURLs {
+			http.Error(w, "Too many URLs (max 100)", http.StatusBadRequest)
+			return
+		}
+
+		// Validate action
+		if req.Action != "show" {
+			http.Error(w, "Invalid action: "+req.Action, http.StatusBadRequest)
+			return
+		}
+
+		// Get all raw discovered apps to find sources
+		rawApps := discovery.GetAllRawDiscoveredApps(app)
+		urlToSource := make(map[string]string)
+		for _, a := range rawApps {
+			urlToSource[a.URL] = a.Source
+		}
+
+		// Build overrides based on action
+		var overrides []*models.DiscoveredAppOverride
+		for _, url := range req.URLs {
+			existing := database.GetDiscoveredOverride(app, url)
+			if existing == nil {
+				existing = &models.DiscoveredAppOverride{
+					URL:    url,
+					Source: urlToSource[url],
+					Groups: []string{},
+				}
+			}
+
+			existing.Hidden = false
+			if req.Category != "" {
+				existing.Category = req.Category
+			}
+			if len(req.Groups) > 0 {
+				existing.Groups = req.Groups
+			}
+
+			overrides = append(overrides, existing)
+		}
+
+		// Save all overrides in a batch
+		if err := database.SaveDiscoveredOverridesBatch(app, overrides); err != nil {
+			http.Error(w, "Failed to save: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"status":  "ok",
+			"updated": len(overrides),
+		})
+	}
+}
+
 // AdminDiscoveredAppsHandler manages discovered app overrides (GET/PUT/DELETE).
 func AdminDiscoveredAppsHandler(app *server.App) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/internal/handlers/discovered_test.go
+++ b/internal/handlers/discovered_test.go
@@ -1,0 +1,161 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestBulkDiscoveredAppsRequest_Validation(t *testing.T) {
+	tests := []struct {
+		name     string
+		req      BulkDiscoveredAppsRequest
+		wantURLs int
+	}{
+		{
+			name:     "show action with single URL",
+			req:      BulkDiscoveredAppsRequest{URLs: []string{"https://app1.local"}, Action: "show", Category: "Tools"},
+			wantURLs: 1,
+		},
+		{
+			name:     "show action with category and groups",
+			req:      BulkDiscoveredAppsRequest{URLs: []string{"https://a.local", "https://b.local"}, Action: "show", Category: "Media", Groups: []string{"users"}},
+			wantURLs: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.req.Action != "show" {
+				t.Errorf("expected action show, got %s", tt.req.Action)
+			}
+			if len(tt.req.URLs) != tt.wantURLs {
+				t.Errorf("expected %d URLs, got %d", tt.wantURLs, len(tt.req.URLs))
+			}
+		})
+	}
+}
+
+func TestBulkDiscoveredAppsRequest_JSONParsing(t *testing.T) {
+	jsonBody := `{"urls":["https://app1.local","https://app2.local"],"action":"show","category":"Media"}`
+
+	var req BulkDiscoveredAppsRequest
+	err := json.Unmarshal([]byte(jsonBody), &req)
+	if err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	if len(req.URLs) != 2 {
+		t.Errorf("expected 2 URLs, got %d", len(req.URLs))
+	}
+	if req.Action != "show" {
+		t.Errorf("expected action show, got %s", req.Action)
+	}
+}
+
+func TestBulkDiscoveredAppsRequest_WithCategoryAndGroups(t *testing.T) {
+	jsonBody := `{"urls":["https://app.local"],"action":"show","category":"Media","groups":["users","admins"]}`
+
+	var req BulkDiscoveredAppsRequest
+	err := json.Unmarshal([]byte(jsonBody), &req)
+	if err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	if req.Category != "Media" {
+		t.Errorf("expected category Media, got %s", req.Category)
+	}
+	if len(req.Groups) != 2 {
+		t.Errorf("expected 2 groups, got %d", len(req.Groups))
+	}
+}
+
+func TestBulkDiscoveredAppsHandler_MethodNotAllowed(t *testing.T) {
+	handler := BulkDiscoveredAppsHandler(nil)
+
+	methods := []string{http.MethodGet, http.MethodPut, http.MethodDelete, http.MethodPatch}
+
+	for _, method := range methods {
+		t.Run(method, func(t *testing.T) {
+			req := httptest.NewRequest(method, "/api/admin/discovered-apps/bulk", nil)
+			w := httptest.NewRecorder()
+			handler(w, req)
+
+			if w.Code != http.StatusMethodNotAllowed {
+				t.Errorf("expected 405, got %d", w.Code)
+			}
+		})
+	}
+}
+
+func TestBulkDiscoveredAppsHandler_InvalidJSON(t *testing.T) {
+	handler := BulkDiscoveredAppsHandler(nil)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/admin/discovered-apps/bulk", bytes.NewReader([]byte("invalid json")))
+	w := httptest.NewRecorder()
+	handler(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestBulkDiscoveredAppsHandler_EmptyURLs(t *testing.T) {
+	handler := BulkDiscoveredAppsHandler(nil)
+
+	body, _ := json.Marshal(BulkDiscoveredAppsRequest{
+		URLs:   []string{},
+		Action: "show",
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/admin/discovered-apps/bulk", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	handler(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestBulkDiscoveredAppsHandler_InvalidAction(t *testing.T) {
+	handler := BulkDiscoveredAppsHandler(nil)
+
+	body, _ := json.Marshal(BulkDiscoveredAppsRequest{
+		URLs:   []string{"https://app.local"},
+		Action: "invalid",
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/admin/discovered-apps/bulk", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	handler(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestBulkDiscoveredAppsHandler_TooManyURLs(t *testing.T) {
+	handler := BulkDiscoveredAppsHandler(nil)
+
+	// Create 101 URLs to exceed the limit of 100
+	urls := make([]string, 101)
+	for i := range urls {
+		urls[i] = fmt.Sprintf("https://app%d.local", i)
+	}
+
+	body, _ := json.Marshal(BulkDiscoveredAppsRequest{
+		URLs:   urls,
+		Action: "show",
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/admin/discovered-apps/bulk", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	handler(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ import (
 
 // Version is set at build time via -ldflags "-X main.Version=...".
 // Falls back to "dev" for local development.
-var Version = "1.0.5"
+var Version = "1.0.6"
 
 // neuteredFileSystem wraps http.FileSystem to disable directory listings.
 // Requests for directories without an index.html will return 404.

--- a/main.go
+++ b/main.go
@@ -257,6 +257,7 @@ func main() {
 	// Discovered apps
 	mux.HandleFunc("/api/discovered-apps", handlers.DiscoveredAppsHandler(app))
 	mux.HandleFunc("/api/admin/discovered-apps", auth.RequireAdmin(app, handlers.AdminDiscoveredAppsHandler(app)))
+	mux.HandleFunc("/api/admin/discovered-apps/bulk", auth.RequireAdmin(app, handlers.BulkDiscoveredAppsHandler(app)))
 
 	// Discovery management
 	mux.HandleFunc("/api/admin/docker-discovery", auth.RequireAdmin(app, handlers.DockerDiscoveryHandler(app)))

--- a/static/css/dashgate.css
+++ b/static/css/dashgate.css
@@ -3150,3 +3150,113 @@
             color: var(--text-primary);
             word-break: break-all;
         }
+
+        /* Bulk selection styles */
+        .discovered-app-checkbox {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            width: 24px;
+            min-width: 24px;
+            height: 24px;
+            margin-right: 8px;
+            cursor: pointer;
+        }
+
+        .discovered-app-checkbox input[type="checkbox"] {
+            width: 16px;
+            height: 16px;
+            cursor: pointer;
+            accent-color: var(--accent);
+        }
+
+        .discovered-app-item.selected {
+            background: var(--accent-bg, rgba(10, 132, 255, 0.1));
+            border-color: var(--accent);
+        }
+
+        .discovered-select-all {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 4px 8px;
+            cursor: pointer;
+        }
+
+        .discovered-select-all input[type="checkbox"] {
+            width: 16px;
+            height: 16px;
+            cursor: pointer;
+            accent-color: var(--accent);
+        }
+
+        .discovered-bulk-actions {
+            display: none;
+            align-items: center;
+            gap: 8px;
+            padding: 10px 12px;
+            margin-bottom: 12px;
+            background: var(--bg-tertiary);
+            border-radius: 10px;
+            border: 1px solid var(--accent);
+        }
+
+        .discovered-bulk-actions.visible {
+            display: flex;
+        }
+
+        .discovered-bulk-actions #bulkSelectedCount {
+            font-size: 12px;
+            font-weight: 500;
+            color: var(--accent);
+            margin-right: 4px;
+        }
+
+        .bulk-action-btn {
+            padding: 5px 12px;
+            border-radius: 6px;
+            font-size: 11px;
+            font-weight: 500;
+            background: var(--accent);
+            color: white;
+            border: none;
+            cursor: pointer;
+            transition: opacity 0.2s;
+        }
+
+        .bulk-action-btn:hover {
+            opacity: 0.85;
+        }
+
+        .bulk-action-btn.secondary {
+            background: var(--bg-elevated);
+            color: var(--text-secondary);
+        }
+
+        .bulk-action-btn.secondary:hover {
+            background: var(--bg-secondary);
+        }
+
+        .bulk-selected-list {
+            max-height: 120px;
+            overflow-y: auto;
+            background: var(--bg-tertiary);
+            border-radius: 8px;
+            padding: 8px;
+            font-size: 12px;
+        }
+
+        .bulk-selected-item {
+            padding: 4px 0;
+            color: var(--text-secondary);
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .bulk-selected-item:last-child {
+            border-bottom: none;
+        }
+
+        .bulk-selected-item-name {
+            color: var(--text-primary);
+            font-weight: 500;
+        }

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -17,7 +17,9 @@
             deleteCallback: null,
             discoveredApps: [],
             staleOverrides: [],
-            discoveredSourceFilter: 'all'
+            discoveredSourceFilter: 'all',
+            selectedDiscoveredApps: new Set(),
+            filteredDiscoveredApps: []
         };
 
         async function loadAdminData() {

--- a/templates/index.html
+++ b/templates/index.html
@@ -1678,12 +1678,20 @@ environment:
                             <input type="text" id="discoveredSearchInput" placeholder="Search discovered apps..." class="admin-search-input" oninput="filterDiscoveredApps()">
                         </div>
                         <div class="discovered-source-filters" id="discoveredSourceFilters">
+                            <label class="discovered-select-all">
+                                <input type="checkbox" id="selectAllDiscovered" onchange="toggleSelectAllDiscovered()">
+                            </label>
                             <button class="discovered-source-filter active" onclick="filterDiscoveredBySource('all')">All</button>
                             <button class="discovered-source-filter" onclick="filterDiscoveredBySource('docker')">Docker</button>
                             <button class="discovered-source-filter" onclick="filterDiscoveredBySource('traefik')">Traefik</button>
                             <button class="discovered-source-filter" onclick="filterDiscoveredBySource('nginx')">Nginx</button>
                             <button class="discovered-source-filter" onclick="filterDiscoveredBySource('npm')">NPM</button>
                             <button class="discovered-source-filter" onclick="filterDiscoveredBySource('caddy')">Caddy</button>
+                        </div>
+                        <div class="discovered-bulk-actions" id="discoveredBulkActions">
+                            <span id="bulkSelectedCount">0 selected</span>
+                            <button class="bulk-action-btn" onclick="openBulkConfigureModal()">Configure</button>
+                            <button class="bulk-action-btn secondary" onclick="clearDiscoveredSelection()">Clear</button>
                         </div>
                         <div class="discovered-apps-list" id="discoveredAppsList">
                             <div class="admin-loading">Loading discovered apps...</div>
@@ -2031,6 +2039,43 @@ environment:
             <div class="admin-modal-footer">
                 <button class="settings-btn" onclick="closeDiscoveredAppModal()">Cancel</button>
                 <button class="settings-btn admin-btn-primary" onclick="saveDiscoveredAppConfig()">Save</button>
+            </div>
+        </div>
+    </div>
+
+    <!-- Bulk Configure Modal -->
+    <div class="admin-modal" id="bulkConfigureModal" role="dialog" aria-modal="true" aria-label="Bulk Configure">
+        <div class="admin-modal-backdrop" onclick="closeBulkConfigureModal()"></div>
+        <div class="admin-modal-content" style="max-width: 450px;">
+            <div class="admin-modal-header">
+                <h3>Configure Selected Apps</h3>
+                <button class="settings-close" onclick="closeBulkConfigureModal()">
+                    <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                        <path d="M18 6L6 18M6 6l12 12"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="admin-modal-body" style="max-height: 70vh; overflow-y: auto;">
+                <div class="admin-form-group">
+                    <label>Selected Apps</label>
+                    <div class="bulk-selected-list" id="bulkSelectedList"></div>
+                </div>
+                <div class="admin-form-group">
+                    <label for="bulkConfigCategory">Category *</label>
+                    <select id="bulkConfigCategory" class="admin-input"></select>
+                </div>
+                <div class="admin-form-group">
+                    <label>Access Groups *</label>
+                    <p class="settings-desc" style="margin-bottom: 8px;">Select which groups can see these apps</p>
+                    <div class="admin-group-checkboxes" id="bulkConfigGroups" style="max-height: 150px;"></div>
+                </div>
+                <p class="settings-desc" style="margin-top: 12px; font-size: 11px; color: var(--text-tertiary);">
+                    Other settings (name, URL, icon, description) can be configured individually via the edit button on each app.
+                </p>
+            </div>
+            <div class="admin-modal-footer">
+                <button class="settings-btn" onclick="closeBulkConfigureModal()">Cancel</button>
+                <button class="settings-btn admin-btn-primary" onclick="applyBulkConfigure()">Apply</button>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary

- Add checkboxes to discovered apps list for multi-selection
- Add bulk configure modal to set category and groups for multiple apps at once
- Add bulk API endpoint with rate limiting (max 100 URLs)
- Add batch database operations with transaction support
- Optimize DOM updates for select-all/clear operations

Closes #6

## Test plan

- [ ] Select multiple discovered apps using checkboxes
- [ ] Use select-all checkbox to select/deselect all visible apps
- [ ] Click "Configure" to open bulk configure modal
- [ ] Verify selected apps are listed in modal
- [ ] Set category and groups, click Apply
- [ ] Verify all selected apps are configured with chosen settings
- [ ] Verify apps appear on dashboard in correct category