### PR TITLE
feat: add Unraid discovery via GraphQL API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.7] - 2026-02-05
+
+### Added
+- **Unraid discovery** — discover Docker containers from Unraid 7.2+ via GraphQL API with `x-api-key` authentication
+- **Unraid CA template support** — handle `[IP]` and `[PORT:default]` placeholders in WebUI URLs, resolve relative icon paths against Unraid server
+- **Unraid connection testing** — test API connectivity and view container count from admin UI
+
 ## [1.0.6] - 2026-02-05
 
 ### Added
@@ -121,6 +128,7 @@ Initial public release.
 - Nginx configuration file parsing for server blocks
 - Nginx Proxy Manager proxy host discovery via API
 - Caddy reverse proxy route discovery via admin API
+- Unraid Docker container discovery via GraphQL API
 - Per-source enable/disable, manual refresh, and connection testing
 - Override system for customizing discovered app display and access
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A self-hosted application gateway for managing and accessing your web services. 
 
 - **Multi-method authentication** - Local accounts, LDAP, OIDC/OAuth2, and reverse proxy (Authelia/Authentik) support
 - **Group-based access control** - Show apps only to users in specific groups
-- **Automatic app discovery** - Discover apps from Docker, Traefik, Nginx, Nginx Proxy Manager, and Caddy
+- **Automatic app discovery** - Discover apps from Docker, Traefik, Nginx, Nginx Proxy Manager, Caddy, and Unraid
 - **Health monitoring** - Background health checks with real-time status indicators
 - **First-time setup wizard** - Guided configuration on initial deployment
 - **Admin panel** - Manage users, apps, categories, and discovery sources from the UI
@@ -115,6 +115,9 @@ $env:STATIC_PATH = ".\static"
 | `ENCRYPTION_KEY` | (auto-generated) | 64 hex character AES-256 key for encrypting secrets at rest |
 | `LOGIN_RATE_LIMIT` | `5` | Max login attempts per IP per window |
 | `COOKIE_SECURE` | (auto) | Set to `false` to allow cookies over HTTP (useful behind reverse proxies) |
+| `UNRAID_DISCOVERY` | `false` | Enable Unraid container discovery |
+| `UNRAID_URL` | | Unraid server URL (e.g., `http://tower.local`) |
+| `UNRAID_API_KEY` | | Unraid API key for GraphQL access |
 
 ### App Catalog (`config.yaml`)
 
@@ -253,6 +256,17 @@ Enable with `NPM_DISCOVERY=true`, `NPM_URL`, `NPM_EMAIL`, and `NPM_PASSWORD`. Di
 
 Enable with `CADDY_DISCOVERY=true` and `CADDY_ADMIN_URL=http://localhost:2019`. Discovers reverse proxy routes from the Caddy admin API.
 
+### Unraid
+
+Enable with `UNRAID_DISCOVERY=true`, `UNRAID_URL`, and `UNRAID_API_KEY`. Discovers Docker containers with WebUI URLs configured via the Unraid GraphQL API (requires Unraid 7.2+).
+
+To create an API key on your Unraid server:
+```bash
+unraid-api apikey --name "DashGate" --create --roles ADMIN --json
+```
+
+Or configure via the admin UI under Discovery settings — enter your Unraid server URL and API key, then test the connection.
+
 ### Managing Discovered Apps
 
 Discovered apps are hidden by default. Use the admin panel to:
@@ -317,6 +331,8 @@ All require admin group membership.
 | `GET/POST` | `/api/admin/nginx-discovery` | Nginx discovery config |
 | `GET/POST` | `/api/admin/npm-discovery` | NPM discovery config |
 | `GET/POST` | `/api/admin/caddy-discovery` | Caddy discovery config |
+| `GET/POST/PUT` | `/api/admin/unraid-discovery` | Unraid discovery config |
+| `POST` | `/api/admin/unraid-discovery/test` | Test Unraid connection |
 | `GET` | `/api/admin/backup` | Download backup |
 | `POST` | `/api/admin/restore` | Restore from backup |
 | `GET` | `/api/admin/audit-log` | View audit log |
@@ -359,7 +375,7 @@ dashgate/
     auth/                  # Authentication (OIDC, LDAP, local, proxy, API keys)
     config/                # YAML config loading and app mappings
     database/              # SQLite schema, system config, encryption, audit
-    discovery/             # Auto-discovery (Docker, Traefik, Nginx, NPM, Caddy)
+    discovery/             # Auto-discovery (Docker, Traefik, Nginx, NPM, Caddy, Unraid)
     handlers/              # HTTP request handlers
     health/                # Background health checker
     lldap/                 # LLDAP API client

--- a/internal/database/encryption.go
+++ b/internal/database/encryption.go
@@ -32,6 +32,7 @@ var sensitiveKeys = map[string]bool{
 	"npm_password":       true,
 	"traefik_password":   true,
 	"caddy_password":     true,
+	"unraid_api_key":     true,
 }
 
 // IsSensitiveKey returns true if the given system_config key holds a secret

--- a/internal/database/system_config.go
+++ b/internal/database/system_config.go
@@ -147,6 +147,12 @@ func LoadSystemConfig(app *server.App) error {
 			app.SystemConfig.CaddyUsername = value
 		case "caddy_password":
 			app.SystemConfig.CaddyPassword = value
+		case "unraid_discovery_enabled":
+			app.SystemConfig.UnraidDiscoveryEnabled = value == "true"
+		case "unraid_url":
+			app.SystemConfig.UnraidURL = value
+		case "unraid_api_key":
+			app.SystemConfig.UnraidAPIKey = value
 		}
 	}
 
@@ -222,6 +228,9 @@ func SaveSystemConfig(app *server.App) error {
 		"caddy_admin_url":           app.SystemConfig.CaddyAdminURL,
 		"caddy_username":            app.SystemConfig.CaddyUsername,
 		"caddy_password":            app.SystemConfig.CaddyPassword,
+		"unraid_discovery_enabled":  strconv.FormatBool(app.SystemConfig.UnraidDiscoveryEnabled),
+		"unraid_url":                app.SystemConfig.UnraidURL,
+		"unraid_api_key":            app.SystemConfig.UnraidAPIKey,
 	}
 	app.SysConfigMu.RUnlock()
 

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -38,6 +38,9 @@ func GetAllRawDiscoveredApps(app *server.App) []models.DiscoveredAppWithOverride
 	if app.CaddyDiscovery.Enabled {
 		addApps(app.CaddyDiscovery.GetApps(), "caddy")
 	}
+	if app.UnraidDiscovery.Enabled {
+		addApps(app.UnraidDiscovery.GetApps(), "unraid")
+	}
 
 	return result
 }

--- a/internal/discovery/unraid.go
+++ b/internal/discovery/unraid.go
@@ -1,0 +1,289 @@
+package discovery
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"dashgate/internal/models"
+	"dashgate/internal/server"
+	"dashgate/internal/urlvalidation"
+
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+const unraidGraphQLQuery = `{
+  docker {
+    containers {
+      id
+      names
+      state
+      labels
+      image
+      autoStart
+    }
+  }
+}`
+
+// InitUnraidDiscovery checks environment variables and system config,
+// then starts the Unraid discovery loop if enabled.
+func InitUnraidDiscovery(app *server.App) {
+	envURL := os.Getenv("UNRAID_URL")
+	envAPIKey := os.Getenv("UNRAID_API_KEY")
+
+	if envURL != "" {
+		app.SysConfigMu.Lock()
+		app.SystemConfig.UnraidURL = envURL
+		app.SysConfigMu.Unlock()
+	}
+	if envAPIKey != "" {
+		app.SysConfigMu.Lock()
+		app.SystemConfig.UnraidAPIKey = envAPIKey
+		app.SysConfigMu.Unlock()
+	}
+
+	if envURL != "" && envAPIKey != "" && os.Getenv("UNRAID_DISCOVERY") == "true" {
+		app.UnraidDiscoveryEnvOverride = true
+		StartUnraidDiscoveryLoop(app)
+		app.SysConfigMu.RLock()
+		log.Printf("Unraid discovery enabled (via environment variable, API: %s)", app.SystemConfig.UnraidURL)
+		app.SysConfigMu.RUnlock()
+	} else if app.SystemConfig.UnraidDiscoveryEnabled && app.SystemConfig.UnraidURL != "" && app.SystemConfig.UnraidAPIKey != "" {
+		StartUnraidDiscoveryLoop(app)
+		app.SysConfigMu.RLock()
+		log.Printf("Unraid discovery enabled (via database config, API: %s)", app.SystemConfig.UnraidURL)
+		app.SysConfigMu.RUnlock()
+	}
+}
+
+// StartUnraidDiscoveryLoop starts the background goroutine that periodically
+// discovers Unraid containers. It is safe to call if already running.
+func StartUnraidDiscoveryLoop(app *server.App) {
+	app.DiscoveryMu.Lock()
+	defer app.DiscoveryMu.Unlock()
+
+	if app.UnraidDiscovery.Stop != nil {
+		return // Already running
+	}
+
+	app.UnraidDiscovery.Enabled = true
+	app.UnraidDiscovery.Stop = make(chan struct{})
+
+	app.UnraidDiscovery.Wg.Add(1)
+	go func() {
+		defer app.UnraidDiscovery.Wg.Done()
+		defer func() {
+			if r := recover(); r != nil {
+				log.Printf("Unraid discovery goroutine panicked: %v", r)
+			}
+		}()
+		ticker := time.NewTicker(60 * time.Second)
+		defer ticker.Stop()
+		DiscoverUnraidApps(app) // Initial discovery
+		for {
+			select {
+			case <-app.UnraidDiscovery.Stop:
+				return
+			case <-ticker.C:
+				DiscoverUnraidApps(app)
+			}
+		}
+	}()
+}
+
+// StopUnraidDiscoveryLoop stops the Unraid discovery background loop
+// and clears all discovered apps.
+func StopUnraidDiscoveryLoop(app *server.App) {
+	app.DiscoveryMu.Lock()
+	if app.UnraidDiscovery.Stop != nil {
+		close(app.UnraidDiscovery.Stop)
+		app.UnraidDiscovery.Stop = nil
+	}
+	app.DiscoveryMu.Unlock()
+
+	app.UnraidDiscovery.Wg.Wait()
+
+	app.DiscoveryMu.Lock()
+	app.UnraidDiscovery.Enabled = false
+	app.UnraidDiscovery.ClearApps()
+	app.DiscoveryMu.Unlock()
+}
+
+// DiscoverUnraidApps queries the Unraid GraphQL API and updates
+// the UnraidDiscovery manager with the results.
+func DiscoverUnraidApps(app *server.App) {
+	app.DiscoveryMu.RLock()
+	enabled := app.UnraidDiscovery.Enabled
+	app.DiscoveryMu.RUnlock()
+	if !enabled {
+		return
+	}
+
+	app.SysConfigMu.RLock()
+	unraidURL := app.SystemConfig.UnraidURL
+	apiKey := app.SystemConfig.UnraidAPIKey
+	app.SysConfigMu.RUnlock()
+
+	if unraidURL == "" || apiKey == "" {
+		return
+	}
+
+	apps, err := queryUnraidContainers(app.HTTPClient, unraidURL, apiKey)
+	if err != nil {
+		log.Printf("Unraid discovery error: %v", err)
+		return
+	}
+
+	app.UnraidDiscovery.SetApps(apps)
+	log.Printf("Unraid discovery found %d app(s)", len(apps))
+}
+
+// queryUnraidContainers queries the Unraid GraphQL API and returns discovered apps.
+func queryUnraidContainers(client *http.Client, unraidURL, apiKey string) ([]models.App, error) {
+	if err := urlvalidation.ValidateDiscoveryURL(unraidURL); err != nil {
+		return nil, fmt.Errorf("Unraid SSRF protection: %w", err)
+	}
+
+	graphqlEndpoint := strings.TrimSuffix(unraidURL, "/") + "/graphql"
+
+	payload := map[string]string{
+		"query": unraidGraphQLQuery,
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal query: %w", err)
+	}
+
+	req, err := http.NewRequest("POST", graphqlEndpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-api-key", apiKey)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		return nil, fmt.Errorf("authentication failed (status %d)", resp.StatusCode)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("API returned status %d", resp.StatusCode)
+	}
+
+	var gqlResp models.UnraidGraphQLResponse
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 10*1024*1024)).Decode(&gqlResp); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	if len(gqlResp.Errors) > 0 {
+		return nil, fmt.Errorf("GraphQL error: %s", gqlResp.Errors[0].Message)
+	}
+
+	var apps []models.App
+	for _, container := range gqlResp.Data.Docker.Containers {
+		// Extract WebUI URL from labels
+		webUIRaw := container.Labels["net.unraid.docker.webui"]
+		if webUIRaw == "" {
+			continue
+		}
+
+		// Get container name (use first name, strip leading slash if present)
+		name := "Unknown"
+		if len(container.Names) > 0 {
+			name = strings.TrimPrefix(container.Names[0], "/")
+			r := strings.NewReplacer("-", " ", "_", " ")
+			name = cases.Title(language.English).String(r.Replace(name))
+		}
+
+		// Map state to status
+		status := "offline"
+		if strings.ToUpper(container.State) == "RUNNING" {
+			status = "online"
+		}
+
+		// Process the WebUI URL - it may contain [IP] placeholder
+		webUIURL := processUnraidWebUIURL(webUIRaw, unraidURL)
+
+		// Extract icon from labels
+		icon := processUnraidIconURL(container.Labels["net.unraid.docker.icon"], unraidURL)
+
+		a := models.App{
+			Name:        name,
+			URL:         webUIURL,
+			Icon:        icon,
+			Description: fmt.Sprintf("Discovered via Unraid (image: %s)", container.Image),
+			Status:      status,
+		}
+
+		apps = append(apps, a)
+	}
+
+	return apps, nil
+}
+
+// processUnraidWebUIURL handles the WebUI URL from Unraid, replacing [IP] placeholder.
+func processUnraidWebUIURL(webUIURL, unraidURL string) string {
+	// Parse the Unraid server URL to get the host
+	parsed, err := url.Parse(unraidURL)
+	if err != nil {
+		return webUIURL
+	}
+
+	// Replace [IP] with the Unraid server IP
+	host := parsed.Hostname()
+	result := strings.ReplaceAll(webUIURL, "[IP]", host)
+
+	// Strip [PORT:xxx] placeholders (CA template syntax), leaving just the default port value
+	for {
+		start := strings.Index(result, "[PORT:")
+		if start == -1 {
+			break
+		}
+		end := strings.Index(result[start:], "]")
+		if end == -1 {
+			break
+		}
+		defaultPort := result[start+6 : start+end]
+		result = result[:start] + defaultPort + result[start+end+1:]
+	}
+
+	return result
+}
+
+// processUnraidIconURL processes the icon URL from Unraid container labels.
+// Relative paths (common in CA templates) are resolved against the Unraid server URL.
+func processUnraidIconURL(iconURL, unraidURL string) string {
+	if iconURL == "" {
+		return ""
+	}
+	if strings.HasPrefix(iconURL, "http://") || strings.HasPrefix(iconURL, "https://") {
+		return iconURL
+	}
+	// Resolve relative paths against the Unraid server (e.g., /state/plugins/... icons)
+	if strings.HasPrefix(iconURL, "/") {
+		return strings.TrimSuffix(unraidURL, "/") + iconURL
+	}
+	return ""
+}
+
+// TestUnraidConnection tests the connection to an Unraid server.
+func TestUnraidConnection(client *http.Client, unraidURL, apiKey string) (int, error) {
+	apps, err := queryUnraidContainers(client, unraidURL, apiKey)
+	if err != nil {
+		return 0, err
+	}
+	return len(apps), nil
+}

--- a/internal/discovery/unraid_integration_test.go
+++ b/internal/discovery/unraid_integration_test.go
@@ -1,0 +1,48 @@
+//go:build integration
+
+package discovery
+
+import (
+	"net/http"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestUnraidIntegration(t *testing.T) {
+	unraidURL := os.Getenv("UNRAID_URL")
+	apiKey := os.Getenv("UNRAID_API_KEY")
+
+	if unraidURL == "" || apiKey == "" {
+		t.Skip("UNRAID_URL and UNRAID_API_KEY required for integration test")
+	}
+
+	client := &http.Client{Timeout: 10 * time.Second}
+
+	apps, err := queryUnraidContainers(client, unraidURL, apiKey)
+	if err != nil {
+		t.Fatalf("queryUnraidContainers failed: %v", err)
+	}
+
+	t.Logf("Found %d apps with WebUI URLs", len(apps))
+	for _, app := range apps {
+		t.Logf("  %-20s %-10s %s (icon: %s)", app.Name, app.Status, app.URL, app.Icon)
+	}
+
+	if len(apps) == 0 {
+		t.Log("WARNING: No apps found. Are there Docker containers with net.unraid.docker.webui labels?")
+	}
+
+	// Verify app properties
+	for _, app := range apps {
+		if app.Name == "" || app.Name == "Unknown" {
+			t.Errorf("app has empty/unknown name")
+		}
+		if app.URL == "" {
+			t.Errorf("app %s has empty URL", app.Name)
+		}
+		if app.Status != "online" && app.Status != "offline" {
+			t.Errorf("app %s has invalid status: %s", app.Name, app.Status)
+		}
+	}
+}

--- a/internal/discovery/unraid_test.go
+++ b/internal/discovery/unraid_test.go
@@ -1,0 +1,405 @@
+package discovery
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"dashgate/internal/models"
+
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+// queryUnraidContainersNoSSRF is a test helper that bypasses SSRF validation.
+func queryUnraidContainersNoSSRF(client *http.Client, graphqlEndpoint, apiKey string) ([]models.App, error) {
+	payload := map[string]string{
+		"query": unraidGraphQLQuery,
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal query: %w", err)
+	}
+
+	req, err := http.NewRequest("POST", graphqlEndpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-api-key", apiKey)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		return nil, fmt.Errorf("authentication failed (status %d)", resp.StatusCode)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("API returned status %d", resp.StatusCode)
+	}
+
+	var gqlResp models.UnraidGraphQLResponse
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 10*1024*1024)).Decode(&gqlResp); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	if len(gqlResp.Errors) > 0 {
+		return nil, fmt.Errorf("GraphQL error: %s", gqlResp.Errors[0].Message)
+	}
+
+	var apps []models.App
+	for _, container := range gqlResp.Data.Docker.Containers {
+		webUIRaw := container.Labels["net.unraid.docker.webui"]
+		if webUIRaw == "" {
+			continue
+		}
+
+		name := "Unknown"
+		if len(container.Names) > 0 {
+			name = strings.TrimPrefix(container.Names[0], "/")
+			r := strings.NewReplacer("-", " ", "_", " ")
+		name = cases.Title(language.English).String(r.Replace(name))
+		}
+
+		status := "offline"
+		if strings.ToUpper(container.State) == "RUNNING" {
+			status = "online"
+		}
+
+		icon := processUnraidIconURL(container.Labels["net.unraid.docker.icon"], "")
+
+		apps = append(apps, models.App{
+			Name:   name,
+			URL:    webUIRaw,
+			Icon:   icon,
+			Status: status,
+		})
+	}
+
+	return apps, nil
+}
+
+func makeContainer(id string, names []string, state string, labels map[string]string, image string) models.UnraidContainer {
+	return models.UnraidContainer{
+		ID:     id,
+		Names:  names,
+		State:  state,
+		Labels: labels,
+		Image:  image,
+	}
+}
+
+func TestQueryUnraidContainers(t *testing.T) {
+	tests := []struct {
+		name           string
+		apiKey         string
+		responseStatus int
+		responseBody   interface{}
+		wantApps       int
+		wantErr        bool
+	}{
+		{
+			name:           "successful response with containers",
+			apiKey:         "test-api-key",
+			responseStatus: http.StatusOK,
+			responseBody: models.UnraidGraphQLResponse{
+				Data: struct {
+					Docker struct {
+						Containers []models.UnraidContainer `json:"containers"`
+					} `json:"docker"`
+				}{
+					Docker: struct {
+						Containers []models.UnraidContainer `json:"containers"`
+					}{
+						Containers: []models.UnraidContainer{
+							makeContainer("abc123", []string{"/plex"}, "RUNNING",
+								map[string]string{
+									"net.unraid.docker.webui": "http://[IP]:32400/web",
+									"net.unraid.docker.icon":  "https://example.com/plex.png",
+								}, "plexinc/pms-docker:latest"),
+							makeContainer("def456", []string{"/sonarr"}, "RUNNING",
+								map[string]string{
+									"net.unraid.docker.webui": "http://[IP]:8989",
+								}, "linuxserver/sonarr:latest"),
+							makeContainer("ghi789", []string{"/redis"}, "RUNNING",
+								map[string]string{}, "redis:alpine"), // No WebUI label
+						},
+					},
+				},
+			},
+			wantApps: 2,
+			wantErr:  false,
+		},
+		{
+			name:           "empty containers list",
+			apiKey:         "test-api-key",
+			responseStatus: http.StatusOK,
+			responseBody: models.UnraidGraphQLResponse{
+				Data: struct {
+					Docker struct {
+						Containers []models.UnraidContainer `json:"containers"`
+					} `json:"docker"`
+				}{
+					Docker: struct {
+						Containers []models.UnraidContainer `json:"containers"`
+					}{
+						Containers: []models.UnraidContainer{},
+					},
+				},
+			},
+			wantApps: 0,
+			wantErr:  false,
+		},
+		{
+			name:           "invalid API key",
+			apiKey:         "wrong-key",
+			responseStatus: http.StatusUnauthorized,
+			responseBody:   nil,
+			wantApps:       0,
+			wantErr:        true,
+		},
+		{
+			name:           "GraphQL error response",
+			apiKey:         "test-api-key",
+			responseStatus: http.StatusOK,
+			responseBody: map[string]interface{}{
+				"errors": []map[string]string{
+					{"message": "Not authorized"},
+				},
+			},
+			wantApps: 0,
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPost {
+					t.Errorf("expected POST method, got %s", r.Method)
+				}
+				if r.URL.Path != "/graphql" {
+					t.Errorf("expected /graphql path, got %s", r.URL.Path)
+				}
+				if apiKey := r.Header.Get("x-api-key"); apiKey != "test-api-key" {
+					w.WriteHeader(http.StatusUnauthorized)
+					return
+				}
+				if ct := r.Header.Get("Content-Type"); ct != "application/json" {
+					t.Errorf("expected Content-Type application/json, got %s", ct)
+				}
+
+				w.WriteHeader(tt.responseStatus)
+				if tt.responseBody != nil {
+					json.NewEncoder(w).Encode(tt.responseBody)
+				}
+			}))
+			defer server.Close()
+
+			client := &http.Client{}
+			apps, err := queryUnraidContainersNoSSRF(client, server.URL+"/graphql", tt.apiKey)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("queryUnraidContainers() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if len(apps) != tt.wantApps {
+				t.Errorf("queryUnraidContainers() got %d apps, want %d", len(apps), tt.wantApps)
+			}
+		})
+	}
+}
+
+func TestProcessUnraidWebUIURL(t *testing.T) {
+	tests := []struct {
+		name      string
+		webUIURL  string
+		unraidURL string
+		want      string
+	}{
+		{
+			name:      "replace [IP] placeholder",
+			webUIURL:  "http://[IP]:32400/web",
+			unraidURL: "http://192.168.1.100",
+			want:      "http://192.168.1.100:32400/web",
+		},
+		{
+			name:      "no placeholder",
+			webUIURL:  "http://192.168.1.100:8989",
+			unraidURL: "http://192.168.1.100",
+			want:      "http://192.168.1.100:8989",
+		},
+		{
+			name:      "hostname URL",
+			webUIURL:  "http://[IP]:9000",
+			unraidURL: "http://tower.local",
+			want:      "http://tower.local:9000",
+		},
+		{
+			name:      "URL with port",
+			webUIURL:  "http://[IP]:8080",
+			unraidURL: "http://192.168.1.100:8443",
+			want:      "http://192.168.1.100:8080",
+		},
+		{
+			name:      "PORT placeholder with default",
+			webUIURL:  "http://[IP]:[PORT:8080]/",
+			unraidURL: "http://192.168.1.100",
+			want:      "http://192.168.1.100:8080/",
+		},
+		{
+			name:      "PORT placeholder in complex URL",
+			webUIURL:  "https://[IP]:[PORT:32400]/web/index.html",
+			unraidURL: "http://tower.local",
+			want:      "https://tower.local:32400/web/index.html",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := processUnraidWebUIURL(tt.webUIURL, tt.unraidURL)
+			if got != tt.want {
+				t.Errorf("processUnraidWebUIURL() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestProcessUnraidIconURL(t *testing.T) {
+	tests := []struct {
+		name      string
+		url       string
+		unraidURL string
+		want      string
+	}{
+		{"https URL", "https://example.com/icon.png", "http://tower.local", "https://example.com/icon.png"},
+		{"http URL", "http://example.com/icon.png", "http://tower.local", "http://example.com/icon.png"},
+		{"empty", "", "http://tower.local", ""},
+		{"relative path resolved", "/state/plugins/dynamix.docker.manager/images/plex.png", "http://192.168.1.100", "http://192.168.1.100/state/plugins/dynamix.docker.manager/images/plex.png"},
+		{"relative path with trailing slash", "/icons/app.png", "http://tower.local/", "http://tower.local/icons/app.png"},
+		{"non-relative non-http", "data:image/png;base64,abc", "http://tower.local", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := processUnraidIconURL(tt.url, tt.unraidURL)
+			if got != tt.want {
+				t.Errorf("processUnraidIconURL(%q, %q) = %q, want %q", tt.url, tt.unraidURL, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestContainerStateMapping(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("x-api-key") != "test-key" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		resp := models.UnraidGraphQLResponse{
+			Data: struct {
+				Docker struct {
+					Containers []models.UnraidContainer `json:"containers"`
+				} `json:"docker"`
+			}{
+				Docker: struct {
+					Containers []models.UnraidContainer `json:"containers"`
+				}{
+					Containers: []models.UnraidContainer{
+						makeContainer("1", []string{"/running-app"}, "RUNNING",
+							map[string]string{"net.unraid.docker.webui": "http://localhost:8080"}, "img:latest"),
+						makeContainer("2", []string{"/paused-app"}, "PAUSED",
+							map[string]string{"net.unraid.docker.webui": "http://localhost:8081"}, "img:latest"),
+						makeContainer("3", []string{"/exited-app"}, "EXITED",
+							map[string]string{"net.unraid.docker.webui": "http://localhost:8082"}, "img:latest"),
+					},
+				},
+			},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := &http.Client{}
+	apps, err := queryUnraidContainersNoSSRF(client, server.URL+"/graphql", "test-key")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(apps) != 3 {
+		t.Fatalf("expected 3 apps, got %d", len(apps))
+	}
+
+	expectedStatuses := map[string]string{
+		"Running App": "online",
+		"Paused App":  "offline",
+		"Exited App":  "offline",
+	}
+
+	for _, app := range apps {
+		expected, ok := expectedStatuses[app.Name]
+		if !ok {
+			t.Errorf("unexpected app name: %q", app.Name)
+			continue
+		}
+		if app.Status != expected {
+			t.Errorf("app %s: got status %s, want %s", app.Name, app.Status, expected)
+		}
+	}
+}
+
+func TestTestUnraidConnectionHelper(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("x-api-key") != "valid-key" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		resp := models.UnraidGraphQLResponse{
+			Data: struct {
+				Docker struct {
+					Containers []models.UnraidContainer `json:"containers"`
+				} `json:"docker"`
+			}{
+				Docker: struct {
+					Containers []models.UnraidContainer `json:"containers"`
+				}{
+					Containers: []models.UnraidContainer{
+						makeContainer("1", []string{"/app1"}, "RUNNING",
+							map[string]string{"net.unraid.docker.webui": "http://localhost:8080"}, "img:latest"),
+						makeContainer("2", []string{"/app2"}, "RUNNING",
+							map[string]string{"net.unraid.docker.webui": "http://localhost:8081"}, "img:latest"),
+					},
+				},
+			},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := &http.Client{}
+
+	apps, err := queryUnraidContainersNoSSRF(client, server.URL+"/graphql", "valid-key")
+	if err != nil {
+		t.Errorf("expected no error for valid key, got: %v", err)
+	}
+	if len(apps) != 2 {
+		t.Errorf("expected 2 containers, got %d", len(apps))
+	}
+
+	_, err = queryUnraidContainersNoSSRF(client, server.URL+"/graphql", "invalid-key")
+	if err == nil {
+		t.Error("expected error for invalid key")
+	}
+}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -179,6 +179,9 @@ type SystemConfig struct {
 	CaddyAdminURL           string `json:"caddyAdminUrl"`
 	CaddyUsername           string `json:"caddyUsername"`
 	CaddyPassword           string `json:"-"`
+	UnraidDiscoveryEnabled  bool   `json:"unraidDiscoveryEnabled"`
+	UnraidURL               string `json:"unraidUrl"`
+	UnraidAPIKey            string `json:"-"`
 }
 
 // LDAPAuthConfig holds runtime LDAP authentication configuration.
@@ -238,4 +241,26 @@ type TraefikRouter struct {
 	EntryPoints []string `json:"entryPoints"`
 	Rule        string   `json:"rule"`
 	Service     string   `json:"service"`
+}
+
+// UnraidGraphQLResponse is the response from the Unraid GraphQL API.
+type UnraidGraphQLResponse struct {
+	Data struct {
+		Docker struct {
+			Containers []UnraidContainer `json:"containers"`
+		} `json:"docker"`
+	} `json:"data"`
+	Errors []struct {
+		Message string `json:"message"`
+	} `json:"errors,omitempty"`
+}
+
+// UnraidContainer represents a Docker container from the Unraid GraphQL API.
+type UnraidContainer struct {
+	ID        string            `json:"id"`
+	Names     []string          `json:"names"`
+	State     string            `json:"state"` // RUNNING, PAUSED, EXITED
+	Labels    map[string]string `json:"labels"`
+	Image     string            `json:"image"`
+	AutoStart bool              `json:"autoStart"`
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -56,6 +56,7 @@ type App struct {
 	NginxDiscovery   *DiscoveryManager
 	NPMDiscovery     *DiscoveryManager
 	CaddyDiscovery   *DiscoveryManager
+	UnraidDiscovery  *DiscoveryManager
 	DiscoveryMu      sync.RWMutex
 
 	// Discovery env override flags
@@ -64,6 +65,7 @@ type App struct {
 	NginxDiscoveryEnvOverride   bool
 	NPMDiscoveryEnvOverride     bool
 	CaddyDiscoveryEnvOverride   bool
+	UnraidDiscoveryEnvOverride  bool
 
 	// Discovered app overrides cache
 	DiscoveredOverrides   map[string]*models.DiscoveredAppOverride
@@ -154,6 +156,7 @@ func New() *App {
 		NginxDiscovery:    NewDiscoveryManager(),
 		NPMDiscovery:      NewDiscoveryManager(),
 		CaddyDiscovery:    NewDiscoveryManager(),
+		UnraidDiscovery:   NewDiscoveryManager(),
 		HTTPClient: &http.Client{
 			Timeout: 5 * time.Second,
 		},

--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ import (
 
 // Version is set at build time via -ldflags "-X main.Version=...".
 // Falls back to "dev" for local development.
-var Version = "1.0.6"
+var Version = "1.0.7"
 
 // neuteredFileSystem wraps http.FileSystem to disable directory listings.
 // Requests for directories without an index.html will return 404.
@@ -132,6 +132,7 @@ func main() {
 	discovery.InitNginxDiscovery(app)
 	discovery.InitNPMDiscovery(app)
 	discovery.InitCaddyDiscovery(app)
+	discovery.InitUnraidDiscovery(app)
 
 	// Security middleware
 	loginRateLimit := 5
@@ -270,6 +271,8 @@ func main() {
 	mux.HandleFunc("/api/admin/traefik-discovery/test", auth.RequireAdmin(app, handlers.TraefikTestHandler(app)))
 	mux.HandleFunc("/api/admin/npm-discovery/test", auth.RequireAdmin(app, handlers.NPMTestHandler(app)))
 	mux.HandleFunc("/api/admin/caddy-discovery/test", auth.RequireAdmin(app, handlers.CaddyTestHandler(app)))
+	mux.HandleFunc("/api/admin/unraid-discovery", auth.RequireAdmin(app, handlers.UnraidDiscoveryHandler(app)))
+	mux.HandleFunc("/api/admin/unraid-discovery/test", auth.RequireAdmin(app, handlers.UnraidTestHandler(app)))
 
 	// Backup/Restore
 	mux.HandleFunc("/api/admin/backup", auth.RequireAdmin(app, handlers.BackupHandler(app)))

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -131,6 +131,9 @@
                 // Load Caddy discovery status
                 await loadCaddyDiscoveryStatus();
 
+                // Load Unraid discovery status
+                await loadUnraidDiscoveryStatus();
+
                 // Load discovered apps for management
                 await loadDiscoveredAppsData();
             } catch (e) {
@@ -194,6 +197,7 @@
                     loadNginxDiscoveryStatus(),
                     loadNPMDiscoveryStatus(),
                     loadCaddyDiscoveryStatus(),
+                    loadUnraidDiscoveryStatus(),
                     loadDiscoveredAppsData()
                 ]);
             } catch (e) {

--- a/templates/index.html
+++ b/templates/index.html
@@ -1583,6 +1583,87 @@ environment:
 
                     <div class="settings-divider"></div>
 
+                    <!-- Unraid Discovery -->
+                    <div class="admin-section" id="unraidDiscoverySection">
+                        <div class="admin-section-header">
+                            <h3 class="admin-section-title">Unraid Discovery</h3>
+                            <button class="settings-btn" onclick="refreshUnraidDiscovery()" id="unraidRefreshBtn" style="padding: 6px 12px; font-size: 12px; display: none;">
+                                <svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                                    <path d="M23 4v6h-6"/>
+                                    <path d="M1 20v-6h6"/>
+                                    <path d="M3.51 9a9 9 0 0114.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0020.49 15"/>
+                                </svg>
+                                Refresh
+                            </button>
+                        </div>
+                        <p class="settings-desc" style="margin-bottom: 12px;">Automatically discover Docker containers from Unraid with WebUI configured</p>
+
+                        <div class="settings-row">
+                            <div class="settings-label">
+                                <span>Enable Unraid Discovery</span>
+                                <span class="settings-hint" id="unraidStatusHint">Not configured</span>
+                            </div>
+                            <label class="toggle">
+                                <input type="checkbox" id="unraidDiscoveryEnabled" onchange="markDiscoveryDirty(); toggleUnraidSection()">
+                                <span class="toggle-slider"></span>
+                            </label>
+                        </div>
+
+                        <!-- Unraid Config Section -->
+                        <div id="unraidConfigSection" class="auth-config-section" style="display: none;">
+                            <div class="auth-config-inner">
+                                <div class="admin-form-group">
+                                    <label for="unraidUrl">Unraid Server URL *</label>
+                                    <input type="url" id="unraidUrl" class="admin-input" placeholder="http://tower.local" onchange="markDiscoveryDirty()">
+                                </div>
+                                <div class="admin-form-group">
+                                    <label for="unraidApiKey">API Key *</label>
+                                    <input type="password" id="unraidApiKey" class="admin-input" placeholder="Enter API key" onchange="markDiscoveryDirty()">
+                                </div>
+                                <p class="settings-desc" style="margin-bottom: 8px;">Generate API key at Settings → Management Access → API Keys (requires Unraid 7.2+ or Connect plugin)</p>
+                                <div style="display: flex; align-items: center; gap: 8px; margin-top: 8px;">
+                                    <button class="settings-btn" onclick="testUnraidConnection()">Test Connection</button>
+                                    <span id="unraidTestResult" style="font-size: 12px;"></span>
+                                </div>
+                                <div id="unraidEnvOverride" class="env-override-notice" style="display: none; margin-top: 8px;">
+                                    <svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                                        <circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/>
+                                    </svg>
+                                    <span>Controlled by UNRAID_DISCOVERY environment variable. UI changes won't take effect until the env var is removed.</span>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Unraid Help Section -->
+                        <div id="unraidDiscoveryHelp" style="margin-top: 12px; padding: 12px; background: var(--bg-tertiary); border-radius: 8px;">
+                            <p style="font-size: 13px; margin-bottom: 8px; font-weight: 500;">Setup Instructions</p>
+
+                            <p style="font-size: 12px; color: var(--text-secondary); margin-bottom: 8px;"><strong>Option 1: Configure via UI (recommended)</strong></p>
+                            <ol style="font-size: 12px; color: var(--text-secondary); margin-left: 16px; line-height: 1.8; margin-bottom: 12px;">
+                                <li>Enter your Unraid server URL and API key above</li>
+                                <li>Click "Test Connection" to verify access</li>
+                                <li>Enable the toggle and click "Save Discovery Settings"</li>
+                            </ol>
+
+                            <p style="font-size: 12px; color: var(--text-secondary); margin-bottom: 8px;"><strong>Option 2: Configure via Environment</strong></p>
+                            <ul style="font-size: 12px; color: var(--text-secondary); margin-left: 16px; line-height: 1.8; margin-bottom: 12px;">
+                                <li><code>UNRAID_URL=http://tower.local</code></li>
+                                <li><code>UNRAID_API_KEY=your-api-key</code></li>
+                                <li><code>UNRAID_DISCOVERY=true</code></li>
+                            </ul>
+
+                            <p style="font-size: 12px; color: var(--text-secondary); margin-bottom: 8px;"><strong>docker-compose.yml example:</strong></p>
+                            <pre style="font-size: 11px; background: var(--bg-secondary); padding: 8px; border-radius: 4px; overflow-x: auto;">environment:
+  - UNRAID_URL=http://tower.local
+  - UNRAID_API_KEY=your-api-key
+  - UNRAID_DISCOVERY=true</pre>
+
+                            <p style="font-size: 12px; color: var(--text-secondary); margin-top: 8px;">Only containers with a WebUI URL configured will be discovered.</p>
+                        </div>
+                    </div>
+
+                    <div class="settings-divider"></div>
+
                     <!-- Save Button -->
                     <div style="display: flex; justify-content: flex-end; padding: 8px 0;">
                         <button class="settings-btn admin-btn-primary" id="saveDiscoveryConfig" onclick="saveDiscoverySettings()" disabled>


### PR DESCRIPTION
## Summary

- Discover Docker containers from Unraid 7.2+ servers using the GraphQL API (`/graphql` endpoint, `x-api-key` auth)
- Handle Community Applications template placeholders: `[IP]` replaced with server hostname, `[PORT:default]` resolved to default port value
- Resolve relative icon paths (e.g., `/state/plugins/...`) against the Unraid server URL
- Map container states (RUNNING/PAUSED/EXITED) to online/offline status
- Admin UI: enable/disable toggle, URL + API key fields, test connection button, env override warning
- Configurable via environment variables (`UNRAID_DISCOVERY`, `UNRAID_URL`, `UNRAID_API_KEY`) or admin UI
- API key encrypted at rest with AES-256-GCM (same as other sensitive config)
- Version bump to 1.0.7

## Files Changed

| Area | Files |
|------|-------|
| Core discovery | `internal/discovery/unraid.go` (new) |
| Tests | `internal/discovery/unraid_test.go`, `unraid_integration_test.go` (new) |
| Models | `internal/models/models.go` |
| Handlers | `internal/handlers/admin_discovery.go` |
| Server state | `internal/server/server.go` |
| Database | `internal/database/system_config.go`, `encryption.go` |
| Discovery aggregation | `internal/discovery/discovery.go` |
| Routes | `main.go` |
| Frontend | `static/js/admin-discovery.js`, `admin.js`, `templates/index.html` |
| Docs | `README.md`, `CHANGELOG.md` |

## Test plan

- [x] 16 unit tests pass (`go test ./internal/discovery/... -v`)
- [x] Integration test passes against live Unraid VM with 4 containers
- [x] Build compiles cleanly
- [ ] Manual: enable Unraid discovery in admin UI, enter URL + API key, test connection
- [ ] Manual: verify discovered apps appear on dashboard with correct names/icons/status
- [ ] Manual: verify env var override mode locks UI fields